### PR TITLE
Needed SET SINGLE_USER WITH ROLLBACK IMMEDIATE

### DIFF
--- a/Instructions/Labs/DP-300_07_lab.md
+++ b/Instructions/Labs/DP-300_07_lab.md
@@ -328,7 +328,10 @@ This task will show you how to restore a database.
 	```sql
 	USE master;
 	GO
-
+	
+	ALTER DATABASE WideWorldImporters SET SINGLE_USER WITH ROLLBACK IMMEDIATE
+	GO
+	
 	RESTORE DATABASE WideWorldImporters 
 	FROM URL = 'https://dp300storage.blob.core.windows.net/backups/WideWorldImporters.bak';
 	GO


### PR DESCRIPTION
The restore was failing because the DB is in use. It will throw an error like this 

Msg 3101, Level 16, State 1, Line 6
Exclusive access could not be obtained because the database is in use.
Msg 3013, Level 16, State 1, Line 6
RESTORE DATABASE is terminating abnormally.

We need this change to sort the problem.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-