### PR TITLE
Remove zip file containing outdated exercises

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,11 +34,4 @@ The students will execute two main tasks: make Azure SQL Database geo-redundant,
 
 ## Notes
 
-
-You can download a .zip file containing PDFs of all the lab instructions including images. The file is in the Instructions folder. 
-
-It is strongly recommended that MCTs and Partners access these materials and in turn, provide them separately to students.  Pointing students directly to GitHub to access Lab steps as part of an ongoing class will require them to access yet another UI as part of the course, contributing to a confusing experience for the student. An explanation to the student regarding why they are receiving separate Lab instructions can highlight the nature of an always-changing cloud-based interface and platform. Microsoft Learning support for accessing files on GitHub and support for navigation of the GitHub site is limited to MCTs teaching this course only. 
-
 When copying code from the lab exercises into the lab Virtual Machine, occasionally line breaks will not come across properly. Please verify that the code is correctly copied before executing it. 
-
-


### PR DESCRIPTION
# Module: all
## Lab/Demo: all

Fixes # removed outdated ZIP file containing PDF files

Changes proposed in this pull request:

The zip file contains PDF files that are created from the exercises from the Labs subfolder, including the pictures from the images subfolder. Both subfolders are updated regularly, but the zip file had been updated 16 months ago. So removal of the file leads to less misunderstandings during class.